### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,17 +12,17 @@ categories = ["command-line-interface", "command-line-utilities", "caching"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = "1.0.58"
+anyhow = "1.0.68"
 clap = { version = "3.2.12", features = ["derive"] }
 directories = "4.0.1"
-parse_link_header = "0.3.2"
-reqwest = { version = "0.11.11", features = ["blocking", "json"] }
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0.82"
-flate2 = "1.0.24"
+parse_link_header = "0.3.3"
+reqwest = { version = "0.11.14", features = ["blocking", "json"] }
+serde = { version = "1.0.152", features = ["derive"] }
+serde_json = "1.0.91"
+flate2 = "1.0.25"
 tar = "0.4.38"
 fs_extra = "1.2.0"
 lazy_static = "1.4.0"
 
 [dev-dependencies]
-pretty_assertions = "1.2.1"
+pretty_assertions = "1.3.0"


### PR DESCRIPTION
Except for the `clap` dependency, this PR updates the dependencies used by cmvm. `clap` will be updated in a separate PR.