### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 


### PR DESCRIPTION
Potential fix for [https://github.com/iepsen/cmvm/security/code-scanning/2](https://github.com/iepsen/cmvm/security/code-scanning/2)

To fix the issue, add an explicit `permissions` block to the root of the workflow file. This will apply the permissions to all jobs in the workflow. Since the provided workflow only needs to check out code and run build and test commands, the least privilege permissions such as `contents: read` should suffice. This explicitly limits the permissions of the `GITHUB_TOKEN` to read-only access to the repository contents, which is sufficient for the described tasks.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
